### PR TITLE
Removed print() statements to prevent polluting Keypirinha console

### DIFF
--- a/src/easysearch.py
+++ b/src/easysearch.py
@@ -133,12 +133,6 @@ class EasySearch(kp.Plugin):
         else:
             self._open_browser(item, private_mode, new_window)
 
-    def on_activated(self):
-        print('----------')
-
-    def on_deactivated(self):
-        print('----------')
-
     def on_events(self, flags):
         if flags & kp.Events.PACKCONFIG:
             self.on_start()


### PR DESCRIPTION
Removed print statements to stop from polluting the Keypirinha console each time the main search box was opened and closed. As the functions are not used for anything else they could safely be removed.